### PR TITLE
Wrapping into Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM node:alpine
+
+RUN apk update
+
+RUN apk add make
+
+WORKDIR /srv/javascript_port_scanner
+
+COPY Makefile Makefile
+
+COPY package-lock.json package-lock.json
+
+COPY package.json package.json
+
+COPY source source
+
+RUN npm install --dev
+
+RUN make build
+
+ENTRYPOINT ["./node_modules/.bin/http-server", "output"]

--- a/Makefile
+++ b/Makefile
@@ -7,3 +7,9 @@ run:
 build:
 	@echo "Building Javascript Port scanner at 'output' folder."
 	mkdir -p output && cp -r source/assets output && cp source/html/index.html output/index.html
+
+docker-build:
+	docker build -t javascript_port_scanner:latest .
+
+docker-run:
+	docker run --rm -p 8080:8080 javascript_port_scanner

--- a/README.md
+++ b/README.md
@@ -59,6 +59,22 @@ It will run start the HTTP server on port `8080`. Make sure you have ran ```make
 build``` to get output of latest code.
 
 
+## Docker (Testing)
+---
+```
+make docker-build
+```
+
+It command will make the build of the docker image. Make sure [Docker][docker]
+is installed.
+
+```
+make docker-run
+```
+
+It will start the container and bind on port `8080` of the host.
+
+
 ## License
 ---
 [GPL v3][gpl_v3]


### PR DESCRIPTION
Wrapping dependency into Docker container. Such change is parley for testing functionality and it should not be used on production until images for production is available.

Fixing: #2 
