### PR TITLE
Correcting wrong end to end test

### DIFF
--- a/end-to-end-tests/tests/test_user.py
+++ b/end-to-end-tests/tests/test_user.py
@@ -178,7 +178,7 @@ class TestCloudNativeServer(base.TestCase):
 
     def test_only_cloud_native_service_is_detected(self):
         self.port_scan(8050, 9000)
-        self.assert_port_in_result("8080", "Unknown")
+        self.assert_port_in_result("8084", "Unknown")
 
 
 class TestStopAfterStart(base.TestCase):


### PR DESCRIPTION
Expected port for NextCloud was 8080. Which is kind of incorrect because
the existing demo server will run on this port. To avoid conflict,
changing this port to 8084.